### PR TITLE
Some minor enhancements

### DIFF
--- a/lib/valhammer/validations.rb
+++ b/lib/valhammer/validations.rb
@@ -9,7 +9,6 @@ module Valhammer
     def valhammer(opts = {})
       @valhammer_indexes ||= connection.indexes(table_name)
       opts = VALHAMMER_DEFAULT_OPTS.merge(opts)
-      excluded_fields = VALHAMMER_EXCLUDED_FIELDS
       columns_hash.each do |name, column|
         next if name == primary_key
         next if VALHAMMER_EXCLUDED_FIELDS.include?(name)
@@ -57,9 +56,11 @@ module Valhammer
 
       case column.type
       when :integer
-        validations[:numericality] = { only_integer: true }
+        validations[:numericality] = { only_integer: true,
+                                       allow_nil: column.null }
       when :decimal
-        validations[:numericality] = { only_integer: false }
+        validations[:numericality] = { only_integer: false,
+                                       allow_nil: column.null }
       end
     end
 

--- a/lib/valhammer/validations.rb
+++ b/lib/valhammer/validations.rb
@@ -4,12 +4,15 @@ module Valhammer
                                numericality: true, length: true }.freeze
     private_constant :VALHAMMER_DEFAULT_OPTS
 
+    VALHAMMER_EXCLUDED_FIELDS = %w(created_at updated_at)
+
     def valhammer(opts = {})
       @valhammer_indexes ||= connection.indexes(table_name)
       opts = VALHAMMER_DEFAULT_OPTS.merge(opts)
-
+      excluded_fields = VALHAMMER_EXCLUDED_FIELDS
       columns_hash.each do |name, column|
         next if name == primary_key
+        next if VALHAMMER_EXCLUDED_FIELDS.include?(name)
 
         validations = valhammer_validations(column, opts)
         validates(name, validations) unless validations.empty?

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -8,6 +8,7 @@ ActiveRecord::Schema.define(version: 0) do
     t.string :description, null: true, default: nil
     t.integer :age, null: true, default: nil
     t.decimal :gpa, null: false, default: 3.0
+    t.integer :socialness, null: false, default: 5
 
     t.timestamps null: false
 

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -9,6 +9,8 @@ ActiveRecord::Schema.define(version: 0) do
     t.integer :age, null: true, default: nil
     t.decimal :gpa, null: false, default: 3.0
 
+    t.timestamps null: false
+
     t.index :identifier, unique: true
   end
 
@@ -17,6 +19,8 @@ ActiveRecord::Schema.define(version: 0) do
 
     t.string :name, null: false, default: nil
 
+    t.timestamps null: false
+
     t.index [:organisation_id, :name], unique: true
   end
 
@@ -24,6 +28,8 @@ ActiveRecord::Schema.define(version: 0) do
     t.string :name, null: false
     t.string :country, null: false
     t.string :city, null: false
+
+    t.timestamps null: false
 
     t.index [:country, :name], unique: true
     t.index [:city, :name], unique: true

--- a/spec/lib/valhammer/validations_spec.rb
+++ b/spec/lib/valhammer/validations_spec.rb
@@ -77,12 +77,21 @@ RSpec.describe Valhammer::Validations do
   end
 
   context 'with an integer column' do
-    let(:opts) { { only_integer: true } }
-    it { is_expected.to include(a_validator_for(:age, :numericality, opts)) }
+    context 'with allow_nil' do
+      let(:opts) { { only_integer: true, allow_nil: true } }
+      it { is_expected.to include(a_validator_for(:age, :numericality, opts)) }
+    end
+    context 'without allow_nil' do
+      let(:opts) { { only_integer: true, allow_nil: false } }
+      it 'sets allow_nil to false for socialness' do
+        expect(subject)
+          .to include(a_validator_for(:socialness, :numericality, opts))
+      end
+    end
   end
 
   context 'with a numeric column' do
-    let(:opts) { { only_integer: false } }
+    let(:opts) { { only_integer: false, allow_nil: false } }
     it { is_expected.to include(a_validator_for(:gpa, :numericality, opts)) }
   end
 

--- a/spec/lib/valhammer/validations_spec.rb
+++ b/spec/lib/valhammer/validations_spec.rb
@@ -46,6 +46,8 @@ RSpec.describe Valhammer::Validations do
 
   context 'with non-nullable columns' do
     it { is_expected.not_to include(a_validator_for(:id, :presence)) }
+    it { is_expected.not_to include(a_validator_for(:created_at, :presence)) }
+    it { is_expected.not_to include(a_validator_for(:updated_at, :presence)) }
     it { is_expected.to include(a_validator_for(:name, :presence)) }
     it { is_expected.to include(a_validator_for(:mail, :presence)) }
     it { is_expected.to include(a_validator_for(:identifier, :presence)) }


### PR DESCRIPTION
This PR addresses a couple of minor issues:

1. **Rails 5 will set created_at/updated_at as non null**

    With applications that have already adopted this new default migration style valhammer causes a validation fault on these fields even though
they are set within ActiveModel #save like `primary_key`.
    
    Some consideration could be given to extending this approach to allowing client apps to also exclude specific fields of their choosing.
  
1. **Numeric fields did not support allow_nil**

    This caused problems for foreign keys that allowed the relationship to be nil.