### PR TITLE
Handle associations as a special case

### DIFF
--- a/lib/valhammer/validations.rb
+++ b/lib/valhammer/validations.rb
@@ -21,7 +21,9 @@ module Valhammer
       return if valhammer_exclude?(name)
 
       assoc = valhammer_assoc(name)
-      return validates(assoc, presence: true) if assoc && !column.null
+      if assoc && !column.null && opts[:presence]
+        return validates(assoc, presence: true)
+      end
 
       validations = valhammer_validations(column, opts)
       validates(name, validations) unless validations.empty?

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -16,7 +16,7 @@ ActiveRecord::Schema.define(version: 0) do
   end
 
   create_table :capabilities, force: true do |t|
-    t.belongs_to :organisation, null: false, default: nil
+    t.belongs_to :organisation, null: true, default: nil
 
     t.string :name, null: false, default: nil
 

--- a/spec/dummy/app/models/capability.rb
+++ b/spec/dummy/app/models/capability.rb
@@ -1,5 +1,5 @@
 class Capability < ActiveRecord::Base
-  valhammer
-
   belongs_to :organisation
+
+  valhammer
 end

--- a/spec/dummy/app/models/organisation.rb
+++ b/spec/dummy/app/models/organisation.rb
@@ -1,6 +1,6 @@
 class Organisation < ActiveRecord::Base
-  valhammer
-
   has_many :resources
   has_many :capabilities
+
+  valhammer
 end

--- a/spec/dummy/app/models/resource.rb
+++ b/spec/dummy/app/models/resource.rb
@@ -1,5 +1,5 @@
 class Resource < ActiveRecord::Base
-  valhammer
-
   belongs_to :organisation
+
+  valhammer
 end

--- a/spec/lib/valhammer/validations_spec.rb
+++ b/spec/lib/valhammer/validations_spec.rb
@@ -43,12 +43,26 @@ RSpec.describe Valhammer::Validations do
       expect(subject)
         .not_to include(a_validator_for(:organisation, :numericality))
     end
+
+    it 'excludes validators on the foreign key' do
+      expect(subject)
+        .not_to include(a_validator_for(:organisation_id, :presence))
+      expect(subject)
+        .not_to include(a_validator_for(:organisation_id, :numericality))
+    end
   end
 
   context 'with a nullable association' do
     subject { Capability.validators }
 
     it { is_expected.not_to include(a_validator_for(:organisation, :presence)) }
+
+    it 'excludes validators on the foreign key' do
+      expect(subject)
+        .not_to include(a_validator_for(:organisation_id, :presence))
+      expect(subject)
+        .not_to include(a_validator_for(:organisation_id, :numericality))
+    end
   end
 
   context 'with a unique index' do

--- a/spec/lib/valhammer/validations_spec.rb
+++ b/spec/lib/valhammer/validations_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Valhammer::Validations do
 
   RSpec::Matchers.define :a_validator_for do |field, kind, opts = nil|
     match do |v|
-      v.is_a?(validation_impl(kind)) && v.attributes == [field.to_s] &&
-        (opts.nil? || v.options == opts)
+      v.is_a?(validation_impl(kind)) && (opts.nil? || v.options == opts) &&
+        v.attributes.map(&:to_s) == [field.to_s]
     end
 
     description do
@@ -34,6 +34,21 @@ RSpec.describe Valhammer::Validations do
     it { is_expected.to include(a_validator_for(:identifier, :presence)) }
     it { is_expected.not_to include(a_validator_for(:description, :presence)) }
     it { is_expected.to include(a_validator_for(:gpa, :presence)) }
+  end
+
+  context 'with a non-nullable association' do
+    it { is_expected.to include(a_validator_for(:organisation, :presence)) }
+
+    it 'excludes numericality validator' do
+      expect(subject)
+        .not_to include(a_validator_for(:organisation, :numericality))
+    end
+  end
+
+  context 'with a nullable association' do
+    subject { Capability.validators }
+
+    it { is_expected.not_to include(a_validator_for(:organisation, :presence)) }
   end
 
   context 'with a unique index' do

--- a/spec/lib/valhammer/validations_spec.rb
+++ b/spec/lib/valhammer/validations_spec.rb
@@ -111,6 +111,9 @@ RSpec.describe Valhammer::Validations do
       opts = { disabled_validator => false }
       Class.new(ActiveRecord::Base) do
         self.table_name = 'resources'
+
+        belongs_to :organisation
+
         valhammer(opts)
       end
     end
@@ -126,6 +129,7 @@ RSpec.describe Valhammer::Validations do
           .and not_include(a_validator_for(:mail, :presence))
           .and not_include(a_validator_for(:identifier, :presence))
           .and not_include(a_validator_for(:gpa, :presence))
+          .and not_include(a_validator_for(:organisation, :presence))
       end
     end
 


### PR DESCRIPTION
It doesn't make sense to validate foreign keys in the same way other fields are validated. Instead, we define a `presence` validator if the column is non-nullable, and define no other validators for foreign keys.