### PR TITLE
Correctly support validating boolean fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ end
 
 Generated validations are:
 
-* `:presence` &mdash; added to non-nullable columns
+* `:presence` &mdash; added to non-nullable, non-boolean columns
+* `:inclusion` &mdash; added to boolean columns to emulate the functionality of
+  `presence` which doesn't work correctly for booleans
 * `:uniqueness` &mdash; added to match unique keys
 * `:numericality` &mdash; added to `integer`/`decimal` columns with the
   `only_integer` option set appropriately

--- a/lib/valhammer/validations.rb
+++ b/lib/valhammer/validations.rb
@@ -1,7 +1,8 @@
 module Valhammer
   module Validations
     VALHAMMER_DEFAULT_OPTS = { presence: true, uniqueness: true,
-                               numericality: true, length: true }.freeze
+                               numericality: true, length: true,
+                               inclusion: true }.freeze
 
     VALHAMMER_EXCLUDED_FIELDS = %w(created_at updated_at)
 
@@ -36,6 +37,7 @@ module Valhammer
 
       validations = {}
       valhammer_presence(validations, column, opts)
+      valhammer_inclusion(validations, column, opts)
       valhammer_unique(validations, column, opts)
       valhammer_numeric(validations, column, opts)
       valhammer_length(validations, column, opts)
@@ -46,9 +48,15 @@ module Valhammer
     end
 
     def valhammer_presence(validations, column, opts)
-      return unless opts[:presence]
+      return unless opts[:presence] && column.type != :boolean
 
       validations[:presence] = true unless column.null
+    end
+
+    def valhammer_inclusion(validations, column, opts)
+      return unless opts[:inclusion] && column.type == :boolean
+
+      validations[:inclusion] = { in: [false, true], allow_nil: column.null }
     end
 
     def valhammer_unique(validations, column, opts)

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -9,6 +9,7 @@ ActiveRecord::Schema.define(version: 0) do
     t.integer :age, null: true, default: nil
     t.decimal :gpa, null: false, default: 3.0
     t.integer :socialness, null: false, default: 5
+    t.boolean :injected, null: false, default: false
 
     t.timestamps null: false
 
@@ -19,6 +20,7 @@ ActiveRecord::Schema.define(version: 0) do
     t.belongs_to :organisation, null: true, default: nil
 
     t.string :name, null: false, default: nil
+    t.boolean :core, null: true, default: nil
 
     t.timestamps null: false
 


### PR DESCRIPTION
The `presence` validator in ActiveRecord treats `false` as a missing value, so we need to check that a real boolean value has been assigned instead.