### PR TITLE
Behave properly with nullable fields

### DIFF
--- a/lib/valhammer/validations.rb
+++ b/lib/valhammer/validations.rb
@@ -9,7 +9,7 @@ module Valhammer
     private_constant :VALHAMMER_DEFAULT_OPTS, :VALHAMMER_EXCLUDED_FIELDS
 
     def valhammer(opts = {})
-      @valhammer_indexes ||= connection.indexes(table_name)
+      @valhammer_indexes = connection.indexes(table_name)
       opts = VALHAMMER_DEFAULT_OPTS.merge(opts)
       columns_hash.each do |name, column|
         valhammer_validate(name, column, opts)

--- a/lib/valhammer/validations.rb
+++ b/lib/valhammer/validations.rb
@@ -56,7 +56,7 @@ module Valhammer
     def valhammer_inclusion(validations, column, opts)
       return unless opts[:inclusion] && column.type == :boolean
 
-      validations[:inclusion] = { in: [false, true], allow_nil: column.null }
+      validations[:inclusion] = { in: [false, true], allow_nil: true }
     end
 
     def valhammer_unique(validations, column, opts)

--- a/lib/valhammer/validations.rb
+++ b/lib/valhammer/validations.rb
@@ -69,7 +69,9 @@ module Valhammer
       return unless unique_keys.one?
 
       scope = unique_keys.first.columns[0..-2]
-      validations[:uniqueness] = scope.empty? ? true : { scope: scope }
+
+      opts = validations[:uniqueness] = { allow_nil: true }
+      opts[:scope] = scope if scope.any?
     end
 
     def valhammer_numeric(validations, column, opts)

--- a/lib/valhammer/validations.rb
+++ b/lib/valhammer/validations.rb
@@ -80,10 +80,10 @@ module Valhammer
       case column.type
       when :integer
         validations[:numericality] = { only_integer: true,
-                                       allow_nil: column.null }
+                                       allow_nil: true }
       when :decimal
         validations[:numericality] = { only_integer: false,
-                                       allow_nil: column.null }
+                                       allow_nil: true }
       end
     end
 

--- a/spec/lib/valhammer/validations_spec.rb
+++ b/spec/lib/valhammer/validations_spec.rb
@@ -88,7 +88,9 @@ RSpec.describe Valhammer::Validations do
   context 'with a composite unique index' do
     subject { Capability.validators }
 
-    let(:opts) { { scope: ['organisation_id'], case_sensitive: true } }
+    let(:opts) do
+      { scope: ['organisation_id'], case_sensitive: true, allow_nil: true }
+    end
     it { is_expected.to include(a_validator_for(:name, :uniqueness, opts)) }
   end
 

--- a/spec/lib/valhammer/validations_spec.rb
+++ b/spec/lib/valhammer/validations_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Valhammer::Validations do
   end
 
   context 'with a non-nullable boolean' do
-    let(:opts) { { in: [false, true], allow_nil: false } }
+    let(:opts) { { in: [false, true], allow_nil: true } }
 
     it { is_expected.to include(a_validator_for(:injected, :inclusion, opts)) }
   end

--- a/spec/lib/valhammer/validations_spec.rb
+++ b/spec/lib/valhammer/validations_spec.rb
@@ -103,13 +103,14 @@ RSpec.describe Valhammer::Validations do
   end
 
   context 'with an integer column' do
-    context 'with allow_nil' do
+    context 'with a nullable column' do
       let(:opts) { { only_integer: true, allow_nil: true } }
       it { is_expected.to include(a_validator_for(:age, :numericality, opts)) }
     end
-    context 'without allow_nil' do
-      let(:opts) { { only_integer: true, allow_nil: false } }
-      it 'sets allow_nil to false for socialness' do
+
+    context 'with a non-nullable column' do
+      let(:opts) { { only_integer: true, allow_nil: true } }
+      it 'allows a nil value in the numericality validator' do
         expect(subject)
           .to include(a_validator_for(:socialness, :numericality, opts))
       end
@@ -117,7 +118,7 @@ RSpec.describe Valhammer::Validations do
   end
 
   context 'with a numeric column' do
-    let(:opts) { { only_integer: false, allow_nil: false } }
+    let(:opts) { { only_integer: false, allow_nil: true } }
     it { is_expected.to include(a_validator_for(:gpa, :numericality, opts)) }
   end
 


### PR DESCRIPTION
This changes the `uniqueness`, `numericality` and `inclusion` validators to always allow `nil`. The `presence` validator is always added for a non-nullable column, so the extra `nil` check from other validators is redundant.

The way the validations were being constructed prior to this change results in duplicate messages when a field is `nil`:

```
[3] pry(#<RSpec::ExampleGroups::ValhammerValidations::SanityCheck::Resource>)> subject.gpa = nil
=> nil
[4] pry(#<RSpec::ExampleGroups::ValhammerValidations::SanityCheck::Resource>)> subject.valid?
=> false
[5] pry(#<RSpec::ExampleGroups::ValhammerValidations::SanityCheck::Resource>)> puts subject.errors.full_messages.join("\n")
Gpa can't be blank
Gpa is not a number
=> nil
```

Fixes #6 