### PR TITLE
Fix behaviour for non-nullable boolean columns

### DIFF
--- a/lib/valhammer/validations.rb
+++ b/lib/valhammer/validations.rb
@@ -56,7 +56,7 @@ module Valhammer
     def valhammer_inclusion(validations, column, opts)
       return unless opts[:inclusion] && column.type == :boolean
 
-      validations[:inclusion] = { in: [false, true], allow_nil: true }
+      validations[:inclusion] = { in: [false, true], allow_nil: column.null }
     end
 
     def valhammer_unique(validations, column, opts)

--- a/spec/lib/valhammer/validations_spec.rb
+++ b/spec/lib/valhammer/validations_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Valhammer::Validations do
   end
 
   context 'with a non-nullable boolean' do
-    let(:opts) { { in: [false, true], allow_nil: true } }
+    let(:opts) { { in: [false, true], allow_nil: false } }
 
     it { is_expected.to include(a_validator_for(:injected, :inclusion, opts)) }
   end


### PR DESCRIPTION
The change which introduced the `allow_nil` option to validators has made it so that `nil` value is permitted for boolean columns, and passed through to the database where it hits a database error.