### PR TITLE
Allow valhammer to work with enum in Rails 4.1

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -4,13 +4,13 @@ guard :bundler do
 end
 
 guard :rspec, cmd: 'bundle exec rspec' do
-  watch(/^spec\/.+_spec\.rb$/)
-  watch(/^lib\/(.+)\.rb$/) { |m| "spec/lib/#{m[1]}_spec.rb" }
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^lib/(.+)\.rb$}) { |m| "spec/lib/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb') { 'spec' }
   watch(%r{spec/(db|dummy)/.*\.rb}) { 'spec' }
 end
 
 guard :rubocop do
   watch(/.+\.rb$/)
-  watch(/(?:.+\/)?\.rubocop\.yml$/) { |m| File.dirname(m[0]) }
+  watch(%r{(?:.+/)?\.rubocop\.yml$}) { |m| File.dirname(m[0]) }
 end

--- a/lib/valhammer/validations.rb
+++ b/lib/valhammer/validations.rb
@@ -77,6 +77,8 @@ module Valhammer
     def valhammer_numeric(validations, column, opts)
       return unless opts[:numericality]
 
+      return if defined_enums.key?(column.name)
+
       case column.type
       when :integer
         validations[:numericality] = { only_integer: true,

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -9,6 +9,7 @@ ActiveRecord::Schema.define(version: 0) do
     t.integer :age, null: true, default: nil
     t.decimal :gpa, null: false, default: 3.0
     t.integer :socialness, null: false, default: 5
+    t.integer :sex, null: false, default: 0
     t.boolean :injected, null: false, default: false
 
     t.timestamps null: false

--- a/spec/dummy/app/models/resource.rb
+++ b/spec/dummy/app/models/resource.rb
@@ -1,5 +1,7 @@
 class Resource < ActiveRecord::Base
   belongs_to :organisation
 
+  enum sex: [:mail, :female]
+
   valhammer
 end

--- a/spec/lib/valhammer/validations_spec.rb
+++ b/spec/lib/valhammer/validations_spec.rb
@@ -115,6 +115,10 @@ RSpec.describe Valhammer::Validations do
           .to include(a_validator_for(:socialness, :numericality, opts))
       end
     end
+
+    context 'when used as enum' do
+      it { is_expected.not_to include(a_validator_for(:sex, :numericality)) }
+    end
   end
 
   context 'with a numeric column' do

--- a/valhammer.gemspec
+++ b/valhammer.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |spec|
   spec.license       = 'Apache-2.0'
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(/^bin\//) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activerecord', '~> 4.1'


### PR DESCRIPTION
Previously integer columns used with new enum support in Rails 4.1
would fail with something like:

```
.../.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/activerecord-4.2.1/lib/active_record/validations.rb:79:in
`raise_record_invalid': Validation failed: xyz is not a number
(ActiveRecord::RecordInvalid)
```