### PR TITLE
Tweak the automatic uniqueness validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,39 @@ end
 That is, the last column in the key is the field which gets validated, and the
 other columns form the `scope` argument.
 
+If any of the scope columns are nullable, the validation will be conditional on
+the presence of the scope values. This avoids the situation where your
+underlying database would accept a row (because it considers `NULL` values not
+equal to each other, which is true of [SQLite][sqlite-null-index],
+[PostgreSQL][postgres-null-index] and [MySQL/MariaDB][mysql-null-index] at the
+least.)
+
+If the above example table had nullable columns, for example:
+
+```ruby
+create_table(:widgets) do |t|
+  t.string :supplier_code, null: true, default: nil
+  t.string :item_code, null: true, default: nil
+
+  t.index [:supplier_code, :item_code], unique: true
+end
+```
+
+This amended table structure causes Valhammer to create validations as though
+you had written:
+
+```ruby
+class Widget < ActiveRecord::Base
+  validates :item_code, uniqueness: { scope: :supplier_code,
+                                      if: -> { supplier_code },
+                                      allow_nil: true }
+end
+```
+
+[sqlite-null-index]: https://www.sqlite.org/lang_createindex.html
+[postgres-null-index]: http://www.postgresql.org/docs/9.0/static/indexes-unique.html
+[mysql-null-index]: https://dev.mysql.com/doc/refman/5.0/en/create-index.html
+
 ## Duplicate Unique Keys
 
 Valhammer is able to handle the simple case when multiple unique keys reference

--- a/README.md
+++ b/README.md
@@ -216,6 +216,24 @@ anyway, if it means your association queries benefit from the index).
 
 Alternatively, apply the validation yourself using ActiveRecord.
 
+## Partial Unique Keys
+
+When a unique key is partially applied to a relation, that key will not be given
+a uniqueness validation.
+
+```ruby
+create_table(:widgets) do |t|
+  t.string :supplier_code, null: true, default: nil
+  t.string :item_code, null: true, default: nil
+
+  t.index [:supplier_code, :item_code], unique: true,
+                                        where: 'item_code LIKE "a%"'
+end
+```
+
+In this case, it is not possible for valhammer to determine the behaviour of the
+`where` clause, so the validation must be manually created.
+
 ## Contributing
 
 Refer to [GitHub Flow](https://guides.github.com/introduction/flow/) for

--- a/lib/valhammer/validations.rb
+++ b/lib/valhammer/validations.rb
@@ -70,8 +70,16 @@ module Valhammer
 
       scope = unique_keys.first.columns[0..-2]
 
-      opts = validations[:uniqueness] = { allow_nil: true }
+      validations[:uniqueness] = valhammer_unique_opts(scope)
+    end
+
+    def valhammer_unique_opts(scope)
+      nullable = scope.select { |c| columns_hash[c].null }
+
+      opts = { allow_nil: true }
       opts[:scope] = scope if scope.any?
+      opts[:if] = -> { nullable.all? { |c| send(c) } } if nullable.any?
+      opts
     end
 
     def valhammer_numeric(validations, column, opts)

--- a/lib/valhammer/validations.rb
+++ b/lib/valhammer/validations.rb
@@ -62,10 +62,7 @@ module Valhammer
     def valhammer_unique(validations, column, opts)
       return unless opts[:uniqueness]
 
-      unique_keys = @valhammer_indexes.select do |i|
-        i.unique && i.columns.last == column.name
-      end
-
+      unique_keys = valhammer_unique_keys(column)
       return unless unique_keys.one?
 
       scope = unique_keys.first.columns[0..-2]
@@ -114,6 +111,12 @@ module Valhammer
 
     def valhammer_exclude?(field)
       field == primary_key || VALHAMMER_EXCLUDED_FIELDS.include?(field)
+    end
+
+    def valhammer_unique_keys(column)
+      @valhammer_indexes.select do |i|
+        i.unique && !i.where && i.columns.last == column.name
+      end
     end
 
     def valhammer_assoc_name(field)

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -15,6 +15,7 @@ ActiveRecord::Schema.define(version: 0) do
     t.timestamps null: false
 
     t.index :identifier, unique: true
+    t.index [:organisation_id, :name], unique: true
   end
 
   create_table :capabilities, force: true do |t|

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -22,11 +22,13 @@ ActiveRecord::Schema.define(version: 0) do
     t.belongs_to :organisation, null: true, default: nil
 
     t.string :name, null: false, default: nil
+    t.string :identifier, null: false, default: nil
     t.boolean :core, null: true, default: nil
 
     t.timestamps null: false
 
     t.index [:organisation_id, :name], unique: true
+    t.index :identifier, unique: true, where: 'organisation_id IS NULL'
   end
 
   create_table :organisations, force: true do |t|

--- a/spec/lib/valhammer/validations_spec.rb
+++ b/spec/lib/valhammer/validations_spec.rb
@@ -95,6 +95,12 @@ RSpec.describe Valhammer::Validations do
     it { is_expected.not_to include(a_validator_for(:mail, :uniqueness)) }
   end
 
+  context 'with a partial unique index' do
+    subject { Capability.validators }
+
+    it { is_expected.not_to include(a_validator_for(:identifier, :uniqueness)) }
+  end
+
   context 'with a composite unique index' do
     let(:opts) do
       { scope: ['organisation_id'], case_sensitive: true, allow_nil: true }

--- a/spec/lib/valhammer/validations_spec.rb
+++ b/spec/lib/valhammer/validations_spec.rb
@@ -117,11 +117,15 @@ RSpec.describe Valhammer::Validations do
       o = Organisation.create!(country: 'Australia', city: 'Brisbane',
                                name: 'Test Organisation')
 
-      attrs = { organisation_id: o.id, name: 'Software Development' }
+      attrs = { organisation_id: o.id, name: 'Software Development',
+                identifier: SecureRandom.urlsafe_base64 }
 
       Capability.create!(attrs)
+
+      attrs[:identifier] = SecureRandom.urlsafe_base64
       Capability.create!(attrs.merge(organisation_id: nil))
 
+      attrs[:identifier] = SecureRandom.urlsafe_base64
       expect(Capability.new(attrs.merge(organisation_id: nil))).to be_valid
       expect(Capability.new(attrs)).not_to be_valid
     end
@@ -257,7 +261,7 @@ RSpec.describe Valhammer::Validations do
     context Capability do
       subject do
         Capability.create!(organisation: organisation, core: true,
-                           name: 'Project Management')
+                           name: 'Project Management', identifier: 'pm')
       end
 
       it { is_expected.to be_valid }

--- a/spec/lib/valhammer/validations_spec.rb
+++ b/spec/lib/valhammer/validations_spec.rb
@@ -1,4 +1,11 @@
 RSpec.describe Valhammer::Validations do
+  around do |example|
+    ActiveRecord::Base.transaction do
+      example.run
+      fail(ActiveRecord::Rollback)
+    end
+  end
+
   def validation_impl(kind)
     name = "#{kind.to_s.camelize}Validator"
 
@@ -10,8 +17,11 @@ RSpec.describe Valhammer::Validations do
   end
 
   RSpec::Matchers.define :a_validator_for do |field, kind, opts = nil|
+    include RSpec::Matchers::Composable
+
     match do |v|
-      v.is_a?(validation_impl(kind)) && (opts.nil? || v.options == opts) &&
+      v.is_a?(validation_impl(kind)) &&
+        (opts.nil? || values_match?(opts, v.options)) &&
         v.attributes.map(&:to_s) == [field.to_s]
     end
 
@@ -86,12 +96,35 @@ RSpec.describe Valhammer::Validations do
   end
 
   context 'with a composite unique index' do
-    subject { Capability.validators }
-
     let(:opts) do
       { scope: ['organisation_id'], case_sensitive: true, allow_nil: true }
     end
+
     it { is_expected.to include(a_validator_for(:name, :uniqueness, opts)) }
+  end
+
+  context 'with a composite unique index with nullable scope column' do
+    subject { Capability.validators }
+
+    let(:opts) do
+      { scope: ['organisation_id'], case_sensitive: true, allow_nil: true,
+        if: an_instance_of(Proc) }
+    end
+
+    it { is_expected.to include(a_validator_for(:name, :uniqueness, opts)) }
+
+    it 'skips validation when the nullable scope column is null' do
+      o = Organisation.create!(country: 'Australia', city: 'Brisbane',
+                               name: 'Test Organisation')
+
+      attrs = { organisation_id: o.id, name: 'Software Development' }
+
+      Capability.create!(attrs)
+      Capability.create!(attrs.merge(organisation_id: nil))
+
+      expect(Capability.new(attrs.merge(organisation_id: nil))).to be_valid
+      expect(Capability.new(attrs)).not_to be_valid
+    end
   end
 
   context 'with duplicate unique indexes' do
@@ -205,13 +238,6 @@ RSpec.describe Valhammer::Validations do
   end
 
   context 'sanity check' do
-    around do |example|
-      ActiveRecord::Base.transaction do
-        example.run
-        fail(ActiveRecord::Rollback)
-      end
-    end
-
     let(:organisation) do
       Organisation.create!(name: 'Enhanced Collaborative Methodologies Pty Ltd',
                            country: 'Australia', city: 'Brisbane')

--- a/valhammer.gemspec
+++ b/valhammer.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rails', '~> 4.1'
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rubocop', '~> 0.34'
   spec.add_development_dependency 'guard'
   spec.add_development_dependency 'guard-rubocop'
   spec.add_development_dependency 'guard-rspec'


### PR DESCRIPTION
This resolves two issues I came across while using valhammer:

* Databases don't consider two `NULL` values to be in conflict when uniquely indexed. If columns that participate in a unique key can be set to `NULL`, valhammer will now add the correct condition to the validator.
* Unique indexes can be partially applied, but valhammer was still creating a table-wide uniqueness validation which didn't match the database schema. Since there is no sane way to parse arbitrary SQL and mimic its behaviour in Rails, these validations are skipped.