### PR TITLE
Ensure unique validations are case sensitive

### DIFF
--- a/lib/valhammer/validations.rb
+++ b/lib/valhammer/validations.rb
@@ -4,7 +4,7 @@ module Valhammer
                                numericality: true, length: true,
                                inclusion: true }.freeze
 
-    VALHAMMER_EXCLUDED_FIELDS = %w(created_at updated_at)
+    VALHAMMER_EXCLUDED_FIELDS = %w(created_at updated_at).freeze
 
     private_constant :VALHAMMER_DEFAULT_OPTS, :VALHAMMER_EXCLUDED_FIELDS
 

--- a/lib/valhammer/version.rb
+++ b/lib/valhammer/version.rb
@@ -1,3 +1,3 @@
 module Valhammer
-  VERSION = '0.2.0'
+  VERSION = '0.2.0'.freeze
 end

--- a/spec/lib/valhammer/validations_spec.rb
+++ b/spec/lib/valhammer/validations_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Valhammer::Validations do
   around do |example|
     ActiveRecord::Base.transaction do
       example.run
-      fail(ActiveRecord::Rollback)
+      raise(ActiveRecord::Rollback)
     end
   end
 

--- a/spec/lib/valhammer/validations_spec.rb
+++ b/spec/lib/valhammer/validations_spec.rb
@@ -93,6 +93,13 @@ RSpec.describe Valhammer::Validations do
     it { is_expected.not_to include(a_validator_for(:id, :uniqueness)) }
     it { is_expected.to include(a_validator_for(:identifier, :uniqueness)) }
     it { is_expected.not_to include(a_validator_for(:mail, :uniqueness)) }
+
+    it 'creates a case sensitive validator' do
+      opts = { case_sensitive: true, allow_nil: true }
+
+      expect(subject)
+        .to include(a_validator_for(:identifier, :uniqueness, opts))
+    end
   end
 
   context 'with a partial unique index' do


### PR DESCRIPTION
New version of shoulda-matchers has highlighted an issue with unique validations in some applications. Adding this check proves that the validation is being created with the correct options and the issue doesn't lie with valhammer.