### PR TITLE
Use symbolic column names for scoped unique checks

### DIFF
--- a/lib/valhammer/validations.rb
+++ b/lib/valhammer/validations.rb
@@ -74,7 +74,7 @@ module Valhammer
       nullable = scope.select { |c| columns_hash[c].null }
 
       opts = { allow_nil: true }
-      opts[:scope] = scope if scope.any?
+      opts[:scope] = scope.map(&:to_sym) if scope.any?
       opts[:if] = -> { nullable.all? { |c| send(c) } } if nullable.any?
       opts
     end

--- a/spec/lib/valhammer/validations_spec.rb
+++ b/spec/lib/valhammer/validations_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Valhammer::Validations do
 
   context 'with a composite unique index' do
     let(:opts) do
-      { scope: ['organisation_id'], case_sensitive: true, allow_nil: true }
+      { scope: [:organisation_id], case_sensitive: true, allow_nil: true }
     end
 
     it { is_expected.to include(a_validator_for(:name, :uniqueness, opts)) }
@@ -120,7 +120,7 @@ RSpec.describe Valhammer::Validations do
     subject { Capability.validators }
 
     let(:opts) do
-      { scope: ['organisation_id'], case_sensitive: true, allow_nil: true,
+      { scope: [:organisation_id], case_sensitive: true, allow_nil: true,
         if: an_instance_of(Proc) }
     end
 


### PR DESCRIPTION
The difference in how valhammer applies validations, compared to hand-written validations in ActiveRecord, was detected by the newer version of shoulda-matchers which now fails because the applied scope doesn't match the expectations.

Converting the scope columns to symbols brings this in line with how the validations would be written without valhammer.