### PR TITLE
Fix deprecation error from dependency update

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,3 +1,4 @@
+SimpleCov.command_name 'rspec'
 SimpleCov.start do
   add_filter('spec')
 end

--- a/.simplecov
+++ b/.simplecov
@@ -1,6 +1,3 @@
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
-
 SimpleCov.start do
   add_filter('spec')
 end


### PR DESCRIPTION
`CodeClimate::TestReporter` has been "deprecated" (read: completely disabled) as part of the 1.x release of that gem. The associated change has already been made on CI.