### PR TITLE
Maintain case sensitivity on uniqueness

### DIFF
--- a/lib/valhammer/validations.rb
+++ b/lib/valhammer/validations.rb
@@ -153,6 +153,7 @@ module Valhammer
 
     def case_sensitive?(column)
       return true unless column.respond_to?(:case_sensitive?)
+
       column.case_sensitive?
     end
   end

--- a/lib/valhammer/validations.rb
+++ b/lib/valhammer/validations.rb
@@ -103,7 +103,7 @@ module Valhammer
     def valhammer_unique_opts(column, scope)
       nullable = scope.select { |c| columns_hash[c].null }
       opts = { allow_nil: true,
-               case_sensitive: case_sensitive?(column.collation) }
+               case_sensitive: case_sensitive?(column) }
       opts[:scope] = scope.map(&:to_sym) if scope.any?
       opts[:if] = -> { nullable.all? { |c| send(c) } } if nullable.any?
       opts

--- a/spec/lib/valhammer/validations_spec.rb
+++ b/spec/lib/valhammer/validations_spec.rb
@@ -90,12 +90,11 @@ RSpec.describe Valhammer::Validations do
   end
 
   context 'with a unique index' do
-
     it { is_expected.not_to include(a_validator_for(:id, :uniqueness)) }
     it { is_expected.to include(a_validator_for(:identifier, :uniqueness)) }
     it { is_expected.not_to include(a_validator_for(:mail, :uniqueness)) }
 
-    it 'creates a case insensitive validator' do
+    it 'creates a case sensitive validator' do
       opts = { case_sensitive: true, allow_nil: true }
 
       expect(subject)

--- a/spec/lib/valhammer/validations_spec.rb
+++ b/spec/lib/valhammer/validations_spec.rb
@@ -90,11 +90,12 @@ RSpec.describe Valhammer::Validations do
   end
 
   context 'with a unique index' do
+
     it { is_expected.not_to include(a_validator_for(:id, :uniqueness)) }
     it { is_expected.to include(a_validator_for(:identifier, :uniqueness)) }
     it { is_expected.not_to include(a_validator_for(:mail, :uniqueness)) }
 
-    it 'creates a case sensitive validator' do
+    it 'creates a case insensitive validator' do
       opts = { case_sensitive: true, allow_nil: true }
 
       expect(subject)


### PR DESCRIPTION
Looking for teams input on my decision to maintain `case_sensitivity` in Rails 6.1+ per below:

When upgrading to Rails 6 the following deprecations are provided to models that make use of the uniqueness constraint:

```
DEPRECATION WARNING: Uniqueness validator will no longer enforce case sensitive comparison in Rails 6.1. To continue case sensitive comparison on the :login attribute in Virtual::User model, pass `case_sensitive: true` option explicitly to the uniqueness validator.
```

As we're already reliant on this functionality Valhammer will continue to set it by default.