### PR TITLE
Turn logging off by default & log less if enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,14 @@ end
 In this case, it is not possible for valhammer to determine the behaviour of the
 `where` clause, so the validation must be manually created.
 
+## Logging
+
+To make Valhammer tell you exactly what it's doing, turn on verbose mode:
+
+```ruby
+Valhammer.config.verbose = true
+```
+
 ## Contributing
 
 Refer to [GitHub Flow](https://guides.github.com/introduction/flow/) for

--- a/lib/valhammer.rb
+++ b/lib/valhammer.rb
@@ -1,7 +1,10 @@
 require 'valhammer/version'
-
-module Valhammer
-end
-
+require 'valhammer/configuration'
 require 'valhammer/validations'
 require 'valhammer/railtie' if defined?(Rails::Railtie)
+
+module Valhammer
+  def self.config
+    Configuration.instance
+  end
+end

--- a/lib/valhammer/configuration.rb
+++ b/lib/valhammer/configuration.rb
@@ -1,0 +1,14 @@
+require 'singleton'
+
+module Valhammer
+  class Configuration
+    include Singleton
+
+    def initialize
+      @verbose = false
+    end
+
+    attr_accessor :verbose
+    alias verbose? verbose
+  end
+end

--- a/lib/valhammer/validations.rb
+++ b/lib/valhammer/validations.rb
@@ -64,8 +64,6 @@ module Valhammer
     end
 
     def valhammer_validations(column, opts)
-      logger.debug("Valhammer generating options for #{valhammer_info(column)}")
-
       validations = {}
       valhammer_presence(validations, column, opts)
       valhammer_inclusion(validations, column, opts)
@@ -73,8 +71,10 @@ module Valhammer
       valhammer_numeric(validations, column, opts)
       valhammer_length(validations, column, opts)
 
-      logger.debug("Valhammer options for #{valhammer_log_key(column)} " \
-                   "are: #{validations.inspect}")
+      if Valhammer.config.verbose?
+        logger.debug("Valhammer options for #{valhammer_log_key(column)} " \
+                     "are: #{validations.inspect}")
+      end
       validations
     end
 


### PR DESCRIPTION
Valhammer is most commonly used in Rails apps. Rails apps most commonly run locally with hot-reloading classes and `LOG_LEVEL=debug`. This means that Valhammer emits lots and lots of validation-related debug logs which aren't usually relevant to the developer.

This commit switches logging off by default. If you want the old logs back, you can set Valhammer.config.verbose = true.

This commit also removes one unecessary log statement entirely. It doesn't come back even when verbose is enabled.

Resolves #26 

## Demo

You can try this on FM by running [this branch](https://github.com/ausaccessfed/federationmanager/tree/demo/quiet-valhammer) locally.

## How much log does this kill?

I tried rebooting FM, clearing the boot logs, and visiting /dashboard in three different ways:

- on master — 145 lines 😩
- with `Valhammer.config.verbose = true` — 89 lines 🤓
- with `Valhammer.config.verbose = false` — 33 lines 😎

So it should make it a lot easier to find what you're looking for!